### PR TITLE
Revert PR #6: undo staging merge into main

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,49 +1,24 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <!--
-           ______                            __
-          / ____/___  ____ ___  ____  __  __/ /____  _____
-         / /   / __ \/ __ `__ \/ __ \/ / / / __/ _ \/ ___/
-        / /___/ /_/ / / / / / / /_/ / /_/ / /_/  __/ /
-        \____/\____/_/ /_/ /_/ .___/\__,_/\__/\___/_/
-                            /_/
-                Created with Perplexity Computer
-                https://www.perplexity.ai/computer
-        -->
-
-        <!-- Perplexity Computer Attribution — SEO Meta Tags -->
-        <meta name="generator" content="Perplexity Computer">
-        <meta name="author" content="Perplexity Computer">
-        <meta property="og:see_also" content="https://www.perplexity.ai/computer">
-        <link rel="author" href="https://www.perplexity.ai/computer">
-
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Josh Stein · Developer Advocate</title>
-        <meta name="description" content="Developer Advocate at Celestia Labs. Building proofs of concept, integrations, and documentation for modular blockchains." />
+        <title>Josh Stein</title>
         <link rel="stylesheet" href="style.css" />
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><text y='24' font-size='24' font-family='monospace' fill='%237c5cfc'>jcs</text></svg>" />
-
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-        <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&display=swap" rel="stylesheet">
 
         <!-- Analytics -->
-        <script defer data-domain="jcstein.dev" src="https://plausible.io/js/plausible.js"></script>
-
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-                document.documentElement.setAttribute('data-theme', theme);
-            })();
-        </script>
+        <script
+            defer
+            data-domain="jcstein.dev"
+            src="https://plausible.io/js/plausible.js"
+        ></script>
 
         <!-- Meta Tags -->
-        <meta property="og:title" content="Josh Stein · Developer Advocate" />
-        <meta property="og:description" content="Developer Advocate at Celestia Labs. Building proofs of concept, integrations, and documentation for modular blockchains." />
+        <meta property="og:title" content="Josh Stein - Developer Advocate" />
+        <meta
+            property="og:description"
+            content="Developer Advocate at Celestia Labs. Building modular blockchains, documentation, and developer tools."
+        />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://jcstein.dev" />
         <meta name="twitter:card" content="summary_large_image" />
@@ -51,464 +26,442 @@
         <meta name="twitter:site" content="@JoshCStein" />
     </head>
     <body>
-        <!-- Sticky Navigation -->
-        <nav class="site-nav" id="siteNav" aria-label="Main navigation">
-            <div class="nav-inner">
-                <a href="#top" class="nav-logo" aria-label="Josh Stein, home">
-                    <svg viewBox="0 0 80 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="wordmark">
-                        <text x="0" y="18" font-family="'JetBrains Mono', monospace" font-size="18" font-weight="700" fill="currentColor">jcs</text>
-                        <rect x="52" y="4" width="3" height="14" rx="1.5" fill="var(--color-accent)" opacity="0.9"/>
-                    </svg>
-                </a>
-                <div class="nav-links">
-                    <a href="#about" class="nav-link">About</a>
-                    <a href="#projects" class="nav-link">Projects</a>
-                    <a href="#talks" class="nav-link">Talks</a>
-                    <a href="#writing" class="nav-link">Writing</a>
-                    <a href="#design" class="nav-link">Design</a>
-                </div>
-                <button class="theme-toggle" data-theme-toggle aria-label="Switch to dark mode">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-                    </svg>
-                </button>
-            </div>
-        </nav>
-
         <main>
-            <!-- Hero -->
-            <section class="hero" id="top">
-                <div class="hero-content">
-                    <div class="hero-badge">Developer Advocate @ Celestia Labs</div>
-                    <h1 class="hero-title">Josh Stein</h1>
-                    <p class="hero-description">I build proofs of concept, write documentation, and coordinate integrations for <a href="https://celestia.org">modular blockchains</a>. I care about making complex infrastructure accessible and fun to work with.</p>
-                    <div class="hero-actions">
-                        <a href="https://github.com/jcstein" class="btn btn-primary">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-                            GitHub
-                        </a>
-                        <a href="https://x.com/JoshCStein" class="btn btn-secondary">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-                            @JoshCStein
-                        </a>
-                        <a href="https://warpcast.com/jcs" class="btn btn-secondary">Farcaster</a>
-                        <a href="https://bsky.app/profile/jcs.bsky.social" class="btn btn-secondary">Bluesky</a>
-                    </div>
-                </div>
-                <div class="hero-visual">
-                    <div class="code-window">
-                        <div class="code-titlebar">
-                            <span class="dot dot-red"></span>
-                            <span class="dot dot-yellow"></span>
-                            <span class="dot dot-green"></span>
-                            <span class="code-filename">~/celestia</span>
-                        </div>
-                        <pre class="code-body"><code><span class="code-prompt">$</span> <span class="code-cmd">celestia light start</span>
-<span class="code-output">INFO  Started Celestia light node</span>
-<span class="code-output">INFO  Listening on /ip4/0.0.0.0/tcp/2121</span>
-<span class="code-output">INFO  Syncing headers... <span class="code-success">✓ caught up</span></span>
-<span class="code-prompt">$</span> <span class="code-cmd">echo "building whatever"</span>
-<span class="code-output">building whatever</span>
-<span class="code-prompt">$</span> <span class="code-cursor">█</span></code></pre>
-                    </div>
-                </div>
+            <header>
+                <h1>Josh Stein</h1>
+                <p class="subtitle">Developer Advocate at Celestia Labs</p>
+            </header>
+
+            <section>
+                <p>
+                    I work on the Developer Experience team and focus on
+                    documentation, demos, and hackathons. I am also an editor
+                    for the Celestia Improvement Proposal process, which you can
+                    get involved in at
+                    <a href="https://cips.celestia.org">cips.celestia.org</a>
+                    and
+                    <a href="https://forum.celestia.org">forum.celestia.org</a>.
+                </p>
+
+                <p>
+                    If you're looking to get in touch, I am most active on
+                    <a href="https://github.com/jcstein">GitHub</a>,
+                    <a href="https://x.com/JoshCStein">X</a>,
+                    <a href="https://warpcast.com/jcs">Farcaster</a>, and
+                    <a href="https://bsky.app/profile/jcs.bsky.social"
+                        >Bluesky</a
+                    >.
+                </p>
             </section>
 
-            <!-- About -->
-            <section class="section" id="about">
-                <div class="section-header">
-                    <h2 class="section-title">About</h2>
-                </div>
-                <blockquote class="philosophy">
-                    "Great systems are built on clarity, trust, and a little play."
-                </blockquote>
+            <section>
+                <h2>About</h2>
+                <p>
+                    I began my journey into the computer science world when I
+                    was finishing university during the pandemic. I discovered
+                    my love for making lightweight websites and my love for
+                    blockchains shortly after.
+                </p>
 
-                <div class="about-grid">
-                    <div class="about-text">
-                        <p>I work on the Developer Experience team at <a href="https://celestia.org">Celestia Labs</a>, where I build proofs of concept, coordinate integrations with partner projects, and help maintain documentation. I'm also an editor for the <a href="https://cips.celestia.org">Celestia Improvement Proposal (CIP)</a> process and contribute to network coordination across the Celestia ecosystem. You can get involved at <a href="https://forum.celestia.org">forum.celestia.org</a>.</p>
-                        <p>I've been taking things apart to see how they work for as long as I can remember: old VHS tapes, electronics, anything I could get a screwdriver into at the kitchen table. That curiosity led me to <strong>Thomas Jefferson High School for Science and Technology</strong>, where I studied Java, built robots with C++ and Arduino, and finished a senior research project on ArduRover (a sensor-driven robotics system).</p>
-                        <p>After high school I repaired iPhones, Androids, PCs, and Macs at <strong>Fruit Fixed</strong>, bridging hardware and software in a hands-on way. Then I spent a few years running restaurant operations, where I re-engineered kitchen workflows and cut ticket times by 80%. I co-founded <a href="https://instagram.com/lattice.supply">Lattice Supply</a> (e-commerce on Shopify) and finished my BS in Supply Chain Management &amp; Analytics (with a math minor) at <strong>VCU School of Business</strong>, making the Dean's List twice.</p>
-                        <p>Web3 clicked for me in 2021. I went from <a href="https://buildspace.so">buildspace</a> TA to DevRel Engineer at <a href="https://ankr.com">Ankr</a>, then joined Celestia Labs as a Solutions Engineer before moving into Developer Advocacy. The thread through all of it is the same: figure out how something works, then make it easier for the next person.</p>
-                    </div>
-                    <div class="tech-stack">
-                        <h3 class="stack-label">Tech I work with</h3>
-                        <div class="tags">
-                            <span class="tag">TypeScript</span>
-                            <span class="tag">React</span>
-                            <span class="tag">Rust</span>
-                            <span class="tag">Go</span>
-                            <span class="tag">Swift</span>
-                            <span class="tag">Celestia</span>
-                            <span class="tag">Rollkit</span>
-                            <span class="tag">OP Stack</span>
-                            <span class="tag">Solidity</span>
-                            <span class="tag">Vite</span>
-                            <span class="tag">Node.js</span>
-                            <span class="tag">Raycast</span>
-                        </div>
-                    </div>
-                </div>
+                <p>
+                    I completed my Bachelor of Science in Business concentrating
+                    in Supply Chain Management and Analytics from VCU's School
+                    of Business and a Minor in Mathematics in May 2021. I made
+                    Dean's List in August 2020 and May 2021.
+                </p>
+
+                <p>
+                    In October 2021, I discovered buildspace through Developer
+                    DAO. This led me to my first frontend contract and then a
+                    short gig as a teaching assistant with
+                    <a href="https://buildspace.so">buildspace</a> (see my
+                    <a href="https://buildspace.so/@josh">buildspace profile</a
+                    >). Next, I worked full-time as a Developer Relations
+                    Engineer at <a href="https://ankr.com">Ankr</a>.
+                </p>
+
+                <p>
+                    I'm also hanging out in
+                    <a href="https://developerdao.com">Developer DAO</a> and
+                    <a href="https://peeple.work">Peeple DAO</a>.
+                </p>
+
+                <p>
+                    In the past, I also co-founded
+                    <a href="https://instagram.com/lattice.supply"
+                        >Lattice Supply</a
+                    >
+                    and founded
+                    <a href="https://wellness-dao-2.vercel.app">Wellness DAO</a
+                    >.
+                </p>
             </section>
 
-            <!-- Featured Projects -->
-            <section class="section" id="projects">
-                <div class="section-header">
-                    <h2 class="section-title">Projects</h2>
-                    <p class="section-subtitle">Featured work and open-source tools</p>
-                </div>
-
-                <div class="featured-grid">
-                    <a href="https://github.com/jcstein/node-app" class="project-card project-card--featured">
-                        <div class="card-accent"></div>
-                        <div class="card-content">
-                            <div class="card-tag">Native App</div>
-                            <h3>Quazar</h3>
-                            <p>A native macOS client for running Celestia light nodes. Swift app that brings modular blockchain infrastructure to the desktop.</p>
-                            <div class="card-meta">
-                                <span>Swift</span>
-                                <span>Celestia</span>
-                            </div>
-                        </div>
-                    </a>
-                    <a href="https://celestia.cool" class="project-card">
-                        <div class="card-accent"></div>
-                        <div class="card-content">
-                            <div class="card-tag">Visualization</div>
-                            <h3>celestia.cool</h3>
-                            <p>Playful, real-time mempool visualizer for the Celestia network. Educational and fun.</p>
-                            <div class="card-meta">
-                                <span>React</span>
-                                <span>Vite</span>
-                            </div>
-                        </div>
-                    </a>
-                    <a href="https://github.com/jcstein/dummy_rollup" class="project-card">
-                        <div class="card-accent"></div>
-                        <div class="card-content">
-                            <div class="card-tag">Systems</div>
-                            <h3>dummy_rollup</h3>
-                            <p>A configurable rollup in Rust for posting random blob batches to Celestia. Systems-level proof of concept.</p>
-                            <div class="card-meta">
-                                <span>Rust</span>
-                                <span>Celestia</span>
-                            </div>
-                        </div>
-                    </a>
-                    <a href="https://github.com/jcstein/rainbowkit-vite-tailwind-starter" class="project-card">
-                        <div class="card-accent"></div>
-                        <div class="card-content">
-                            <div class="card-tag">Template</div>
-                            <h3>RainbowKit Starter</h3>
-                            <p>Widely used starter template for RainbowKit + Vite + React + Tailwind CSS projects.</p>
-                            <div class="card-meta">
-                                <span>TypeScript</span>
-                                <span>React</span>
-                            </div>
-                        </div>
-                    </a>
-                    <a href="https://github.com/jcstein/celestia-gas-price" class="project-card">
-                        <div class="card-accent"></div>
-                        <div class="card-content">
-                            <div class="card-tag">Developer Tool</div>
-                            <h3>Celestia Gas Price</h3>
-                            <p>Raycast extension for quick gas price lookups on the Celestia network.</p>
-                            <div class="card-meta">
-                                <span>TypeScript</span>
-                                <span>Raycast</span>
-                            </div>
-                        </div>
-                    </a>
-                    <a href="https://bitkit.dev" class="project-card">
-                        <div class="card-accent"></div>
-                        <div class="card-content">
-                            <div class="card-tag">POC</div>
-                            <h3>Bitkit.dev</h3>
-                            <p>Bitcoin + Rollkit + EVM proof of concept combining multiple blockchain layers.</p>
-                            <div class="card-meta">
-                                <span>Rollkit</span>
-                                <span>EVM</span>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-
-                <details class="more-projects">
-                    <summary>Full archive <span class="count">(18 projects)</span></summary>
-                    <div class="archive-groups">
-                        <section class="archive-group">
-                            <h3 class="archive-group-title">Tools &amp; packages</h3>
-                            <ul class="project-list project-list--grouped">
-                                <li><a href="https://github.com/jcstein/celestia-address">Celestia Address</a>: Raycast extension for Celenium address lookup</li>
-                                <li><a href="https://www.npmjs.com/package/light-nodes">light-nodes</a>: NPM package for celestia-node</li>
-                                <li><a href="https://github.com/jcstein/tg-announcement-bot">Telegram Announcement Bot</a>: multi-channel formatted announcements</li>
-                                <li><a href="https://github.com/jcstein/ScreenNames">Screen Names</a>: macOS screenshot renamer</li>
-                                <li><a href="https://github.com/jcstein/node-ui">Mammoth Control Panel</a>: web UI for a Celestia light node on testnet</li>
-                                <li><a href="https://github.com/jcstein/decentralized-tooling">Decentralized Tooling List</a>: curated resource list</li>
-                            </ul>
-                        </section>
-                        <section class="archive-group">
-                            <h3 class="archive-group-title">POCs &amp; demos</h3>
-                            <ul class="project-list project-list--grouped">
-                                <li><a href="https://github.com/jcstein/dummy_rollup/tree/tictactoe">dummy_rollup (tictactoe)</a>: tic-tac-toe on a Celestia rollup</li>
-                                <li><a href="https://github.com/jcstein/say-moo">Say Moo</a>: Celestia EVM rollup demo</li>
-                                <li><a href="https://github.com/jcstein/gm-portal">GM Portal</a>: Celestia EVM rollup demo</li>
-                                <li><a href="https://github.com/jcstein/base64-svg-celestia">Base64 SVG tutorial</a>: tutorial with Celestia</li>
-                                <li><a href="https://github.com/jcstein/bundlr-js-demo">Bundlr JS demo</a>: Bundlr uploader</li>
-                                <li><a href="https://www.youtube.com/watch?v=YbMX42ILtLA">CelestiaGPT</a>: AI chatbot for Celestia docs</li>
-                            </ul>
-                        </section>
-                        <section class="archive-group">
-                            <h3 class="archive-group-title">Starters &amp; experiments</h3>
-                            <ul class="project-list project-list--grouped">
-                                <li><a href="https://github.com/jcstein/vite-tree">Vite Tree</a>: DIY Linktree with Chakra UI</li>
-                                <li><a href="https://github.com/jcstein/optimistic-loogies">Optimistic Loogies</a>: Scaffold-ETH rollup implementation</li>
-                                <li><a href="https://github.com/jcstein/build-market">build market</a>: NFT marketplace on Goerli</li>
-                                <li><a href="https://github.com/jcstein/multichain-nft-gallery">Multichain NFT Gallery</a>: cross-chain viewer</li>
-                                <li><a href="https://github.com/jcstein/thirdweb-rainbowkit">thirdweb + rainbowkit</a>: ERC-1155 minting starter</li>
-                                <li><a href="https://github.com/jcstein/r3sume">R3sume</a>: resume as an NFT</li>
-                            </ul>
-                        </section>
-                    </div>
-                </details>
+            <section>
+                <h2>Projects</h2>
+                <ul>
+                    <li>
+                        <a href="https://github.com/jcstein/celestia-gas-price"
+                            >Celestia Gas Price</a
+                        >
+                        - Raycast extension for Celestia gas prices
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/celestia-address"
+                            >Celestia Address</a
+                        >
+                        - Raycast extension for viewing Celestia addresses on
+                        Celenium
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/node-ui"
+                            >Mammoth Control Panel</a
+                        >
+                        - A UI to interact with a Celestia light node for mamo-1
+                        testnet
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/tg-announcement-bot"
+                            >Telegram Announcement Bot</a
+                        >
+                        - A Telegram bot for sending formatted announcements to
+                        multiple channels simultaneously
+                    </li>
+                    <li>
+                        <a
+                            href="https://github.com/jcstein/dummy_rollup/tree/tictactoe"
+                            >dummy_rollup with tictactoe</a
+                        >
+                        - Tic-tac-toe game implementation using the Celestia
+                        blockchain
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/dummy_rollup"
+                            >dummy_rollup</a
+                        >
+                        - A dummy rollup project to test posting and retrieving
+                        data from Celestia
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/celestia-cool"
+                            >celestia.cool</a
+                        >
+                        - A Celestia mempool visualization
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=YbMX42ILtLA"
+                            >CelestiaGPT demo</a
+                        >
+                        - AI chatbot for Celestia docs
+                    </li>
+                    <li>
+                        <a href="https://www.npmjs.com/package/light-nodes"
+                            >light-nodes</a
+                        >
+                        - An NPM package for using celestia-node
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/node-app">Quazar</a>
+                        - A Celestia light node client for macOS
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/loogies"
+                            >An implementation of Scaffold-ETH Optimistic
+                            Loogies on a rollup</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://x.com/joshcstein/status/1692415902895997289?s=46"
+                            >Screen Names</a
+                        >
+                        - A lightweight app to help you rename screenshots on
+                        macOS
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/buildmarket-lol"
+                            >build market</a
+                        >
+                        - NFT marketplace on Goerli built with thirdweb
+                    </li>
+                    <li>
+                        <a
+                            href="https://x.com/joshcstein/status/1644341742139834368?s=46"
+                            >Base64 SVG tutorial with Celestia</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/bitkit"
+                            >Bitcoin + Rollkit + EVM demo - Bitkit.dev</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/moo"
+                            >Celestia EVM rollup demo - Say Moo</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/gm-portal"
+                            >Celestia EVM rollup demo - GM Portal</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/bundlr-js"
+                            >Bundlr JS demo uploader</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/r3sum3-2">R3sume</a>
+                        - My resume as an NFT
+                    </li>
+                    <li>
+                        <a href="https://opensea.io/jcstein">On-Chain Resume</a>
+                        - My professional history as NFTs
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/thirdweb-rainbowkit"
+                            >thirdweb + rainbowkit + wagmi + vite ERC-1155
+                            minting site</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/vite-tree"
+                            >Vite Tree</a
+                        >
+                        - DIY React Linketree with Chakra UI
+                    </li>
+                    <li>
+                        <a
+                            href="https://github.com/jcstein/vite-tailwind-starter"
+                            >Vite Tailwind Starter Repository</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://github.com/jcstein/rainbowkit-vite-tailwind-starter"
+                            >RainbowKit Starter (Vite + React + Tailwind CSS)</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://github.com/jcstein/multichain-gallery-ankr"
+                            >Multichain NFT Gallery</a
+                        >
+                    </li>
+                    <li>Ankr Pay-as-you-go Calculator</li>
+                    <li>
+                        <a href="https://joshcs.notion.site/?pvs=74"
+                            >My List of Decentralized Tooling</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://x.com/web3con/status/1627838755154366465?s=46"
+                            >web3con by DeveloperDAO</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://github.com/jcstein/xp-radio"
+                            >XP Radio Linktree-style Chakra UI + React</a
+                        >
+                    </li>
+                    <li>
+                        <a href="https://speedrunethereum.com"
+                            >SpeedRunEthereum.com</a
+                        >
+                    </li>
+                    <li>pointer.gg - Solidity Keyboard Generator</li>
+                    <li>
+                        <a href="https://github.com/jcstein/sequoia-vans"
+                            >Sequoia Vans, i18n demo</a
+                        >
+                    </li>
+                    <li>3SLR Zora Demo</li>
+                    <li>Is SNL New Tonight?</li>
+                </ul>
             </section>
 
-            <!-- Talks -->
-            <section class="section" id="talks">
-                <div class="section-header">
-                    <h2 class="section-title">Talks &amp; Presentations</h2>
-                    <p class="section-subtitle">Conference talks, workshops, and panels across three continents</p>
-                </div>
-
-                <div class="talks-list">
-                    <div class="talk-group">
-                        <h3 class="talk-year">2025</h3>
-                        <div class="talk-items">
-                            <a href="https://www.blog.encode.club/encode-modular-defi-denver-hackathon-research-day-2025-759a6048e154" class="talk-item">
-                                <span class="talk-title">Verifiable AI and the Future of DeFi</span>
-                                <span class="talk-venue">Encode Modular DeFi Denver Hackathon &amp; Research Day 2025, Denver, Colorado · moderator</span>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="talk-group">
-                        <h3 class="talk-year">2024</h3>
-                        <div class="talk-items">
-                            <a href="https://www.youtube.com/watch?v=P3EG5FmUvNI" class="talk-item">
-                                <span class="talk-title">How to build whatever</span>
-                                <span class="talk-venue">Encode Club, Chain Abstraction Series</span>
-                            </a>
-                            <a href="https://www.youtube.com/watch?v=ZCB7y0xIYRI" class="talk-item">
-                                <span class="talk-title">How to build whatever</span>
-                                <span class="talk-venue">Modular Summit 3.0, Brussels, Belgium</span>
-                            </a>
-                            <a href="https://consensus2024.coindesk.com/agenda/event/-how-to-build-whatever-389" class="talk-item">
-                                <span class="talk-title">How to Build Whatever</span>
-                                <span class="talk-venue">Consensus 2024, Austin, Texas</span>
-                            </a>
-                            <a href="https://www.youtube.com/watch?v=ruXxChTdLzo" class="talk-item">
-                                <span class="talk-title">Building with OP Stack</span>
-                                <span class="talk-venue">Infinite Space Bazaar</span>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="talk-group">
-                        <h3 class="talk-year">2023</h3>
-                        <div class="talk-items">
-                            <a href="https://www.youtube.com/watch?v=VQ8dOjPWppo" class="talk-item">
-                                <span class="talk-title">OP Stack Rollup Workshop</span>
-                                <span class="talk-venue">Modular Summit 2.0, Paris, France</span>
-                            </a>
-                            <a href="https://www.youtube.com/watch?v=3kLuHOJariY" class="talk-item">
-                                <span class="talk-title">Celestia Light Node Tutorial</span>
-                                <span class="talk-venue">Modular Summit 2.0, Paris, France</span>
-                            </a>
-                            <a href="https://www.youtube.com/watch?v=_9DCV23CJV0" class="talk-item">
-                                <span class="talk-title">Developer Infrastructure Panel</span>
-                                <span class="talk-venue">Modular Summit 2.0, Paris, France</span>
-                            </a>
-                            <a href="https://www.youtube.com/watch?v=nucX0pLY9JA" class="talk-item">
-                                <span class="talk-title">DevNTell: Modular Blockchains</span>
-                                <span class="talk-venue">Developer DAO</span>
-                            </a>
-                            <a href="https://www.youtube.com/watch?v=KWijOhR5HEU" class="talk-item">
-                                <span class="talk-title">Theory Thursdays: Celestia</span>
-                                <span class="talk-venue">ETH Denver, Denver, Colorado</span>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="talk-group">
-                        <h3 class="talk-year">2022</h3>
-                        <div class="talk-items">
-                            <a href="https://www.youtube.com/watch?v=LS0rqL6Zp1A" class="talk-item">
-                                <span class="talk-title">WAGMI on Polygon, Episode 3</span>
-                                <span class="talk-venue">Polygon</span>
-                            </a>
-                            <div class="talk-item">
-                                <span class="talk-title">Deploy ERC-721 &amp; Mint NFT on Avalanche</span>
-                                <span class="talk-venue">Avalanche House, Berlin, Germany</span>
-                            </div>
-                            <div class="talk-item">
-                                <span class="talk-title">Metaverse Panel with Microsoft, NVIDIA &amp; Meta</span>
-                                <span class="talk-venue">LA Hacks @ UCLA, Los Angeles</span>
-                            </div>
-                            <div class="talk-item">
-                                <span class="talk-title">Ankr Hybrid Infrastructure</span>
-                                <span class="talk-venue">ETH Dubai, Dubai, UAE</span>
-                            </div>
-                            <div class="talk-item">
-                                <span class="talk-title">Web3 Dev Tools: My Journey into Web3</span>
-                                <span class="talk-venue">Avalanche Summit, Barcelona, Spain</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <section>
+                <h2>Presentations</h2>
+                <ul>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=P3EG5FmUvNI"
+                            >How to build whatever</a
+                        >
+                        (Encode Club's Chain Abstraction educate series, 2024)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=ZCB7y0xIYRI"
+                            >How to build whatever</a
+                        >
+                        (Modular Summit 3.0 - Brussels, Belgium, July 2024)
+                    </li>
+                    <li>
+                        <a
+                            href="https://consensus2024.coindesk.com/agenda/event/-how-to-build-whatever-389"
+                            >How to Build Whatever</a
+                        >
+                        (Consensus 2024 - Austin, Texas, May 2024)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=ruXxChTdLzo"
+                            >Building with OP Stack</a
+                        >
+                        (Infinite Space Bazaar, April-May 2024)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=VQ8dOjPWppo"
+                            >OP Stack Rollup Workshop</a
+                        >
+                        (Modular Summit 2.0 - Paris, France, July 2023)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=3kLuHOJariY"
+                            >Celestia Light Node Tutorial</a
+                        >
+                        (Modular Summit 2.0 - Paris, France, July 2023)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=_9DCV23CJV0"
+                            >Developer Infrastructure Panel</a
+                        >
+                        (Modular Summit 2.0 - Paris, France, July 2023)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=nucX0pLY9JA"
+                            >DevNTell - Modular Blockchains</a
+                        >
+                        (Developer DAO, 2023)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=KWijOhR5HEU"
+                            >Theory Thursdays: Celestia w/ Josh Stein</a
+                        >
+                        (ETH Denver 2023 - Denver, Colorado, February 2023)
+                    </li>
+                    <li>
+                        <a href="https://www.youtube.com/watch?v=LS0rqL6Zp1A"
+                            >WAGMI on Polygon - Episode 3 ft Josh Stein</a
+                        >
+                        (July 2022)
+                    </li>
+                    <li>
+                        Deploy an ERC-721 Smart Contract and Mint NFT on
+                        Avalanche with Ankr (Avalanche House - Berlin, Germany,
+                        July 2022)
+                    </li>
+                    <li>
+                        Metaverse Panel with Ankr, Microsoft, NVIDIA, and Meta
+                        (LA Hacks @ UCLA - Los Angeles, California, May 2022)
+                    </li>
+                    <li>
+                        How to Deploy an ERC-721 Contract and Mint Your First
+                        NFT - Workshop (LA Hacks @ UCLA - Los Angeles,
+                        California, April 2022)
+                    </li>
+                    <li>
+                        Ankr Hybrid Infrastructure (ETH Dubai - Dubai, UAE,
+                        March 2022)
+                    </li>
+                    <li>
+                        Web3 Developer Tools: My Journey into Web3 and the Ankr
+                        Premium Plan (Avalanche Summit - Barcelona, Spain, March
+                        2022)
+                    </li>
+                    <li>
+                        Avalanche Summit Hackathon Bounties (Avalanche Summit -
+                        Barcelona, Spain, March 2022)
+                    </li>
+                </ul>
             </section>
 
-            <!-- Writing -->
-            <section class="section" id="writing">
-                <div class="section-header">
-                    <h2 class="section-title">Writing</h2>
-                    <p class="section-subtitle">Blog posts and technical writing</p>
-                </div>
-
-                <div class="writing-grid writing-grid--single">
-                    <div class="writing-column">
-                        <h3 class="writing-heading">Writing</h3>
-                        <div class="writing-links">
-                            <a href="https://paragraph.xyz/@jcs" class="writing-link">
-                                <span class="writing-platform">Paragraph</span>
-                                <span class="writing-arrow">→</span>
-                            </a>
-                            <a href="https://paragraph.com/@joshcstein" class="writing-link">
-                                <span class="writing-platform">Mirror</span>
-                                <span class="writing-arrow">→</span>
-                            </a>
-                            <a href="https://hashnode.com/@jcstein" class="writing-link">
-                                <span class="writing-platform">Hashnode</span>
-                                <span class="writing-arrow">→</span>
-                            </a>
-                            <a href="https://joshcs.substack.com/" class="writing-link">
-                                <span class="writing-platform">Substack</span>
-                                <span class="writing-arrow">→</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
+            <section>
+                <h2>Tutorials</h2>
+                <ul>
+                    <li>
+                        <a
+                            href="https://www.ankr.com/docs/tutorials/polygon-nft/"
+                            >How to Deploy Your First Polygon NFT with an
+                            ERC-721 Solidity Smart Contract and Ankr</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://www.ankr.com/docs/tutorials/avalanche-nft/"
+                            >How to Deploy an ERC-721 Smart Contract to
+                            Avalanche and Mint an NFT with Ankr, Hardhat, and
+                            Ethers.js</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://www.ankr.com/docs/tutorials/deploy-dapp-rainbowkit/"
+                            >Deploy a dApp with RainbowKit, Ankr, React, and
+                            Chakra-UI</a
+                        >
+                    </li>
+                    <li>
+                        <a
+                            href="https://github.com/solana-foundation/solana-pay"
+                            >How to Set Up your own Solana Pay PoS</a
+                        >
+                        (<a
+                            href="https://solana-pay-lyart.vercel.app/new?recipient=8efRxx3LBzXSPFwFj2UgvCsfJjfEkRxDdw2AtUi61Jtb&label=store+name"
+                            >Live Demo</a
+                        >)
+                    </li>
+                </ul>
             </section>
 
-            <!-- Design -->
-            <section class="section" id="design">
-                <div class="section-header">
-                    <h2 class="section-title">Design &amp; Art</h2>
-                    <p class="section-subtitle">Graphics, NFT galleries, and visual work</p>
-                </div>
-
-                <div class="design-gallery">
-                    <a href="dd.png" target="_blank" class="design-item">
-                        <img src="dd.png" alt="Developer DAO vibes logo" loading="lazy" />
-                        <span class="design-caption">Developer DAO vibes logo</span>
-                    </a>
-                    <a href="pn.png" target="_blank" class="design-item">
-                        <img src="pn.png" alt="Developer DAO happy hour banner" loading="lazy" />
-                        <span class="design-caption">Developer DAO happy hour</span>
-                    </a>
-                    <a href="vibes.png" target="_blank" class="design-item">
-                        <img src="vibes.png" alt="Developer DAO member hh banner" loading="lazy" />
-                        <span class="design-caption">Developer DAO member banner</span>
-                    </a>
-                </div>
-
-                <div class="gallery-links">
-                    <h3 class="writing-heading">NFT Galleries</h3>
-                    <div class="writing-links">
-                        <a href="https://deca.art/joshcs/3" class="writing-link">
-                            <span class="writing-platform">Deca</span>
-                            <span class="writing-arrow">→</span>
-                        </a>
-                        <a href="https://oncyber.io/joshstein" class="writing-link">
-                            <span class="writing-platform">oncyber</span>
-                            <span class="writing-arrow">→</span>
-                        </a>
-                    </div>
-                </div>
+            <section>
+                <h2>Writing</h2>
+                <ul>
+                    <li><a href="https://paragraph.xyz/@jcs">Paragraph</a></li>
+                    <li>
+                        <a href="https://paragraph.com/@joshcstein">Mirror</a>
+                    </li>
+                    <li>
+                        <a href="https://hashnode.com/@jcstein">Hashnode</a>
+                    </li>
+                    <li><a href="https://joshcs.substack.com/">Substack</a></li>
+                </ul>
             </section>
+
+            <section>
+                <h2>Design</h2>
+                <ul>
+                    <!--<li>
+                        <a href="https://www.behance.net/joshcstein">Behance</a>
+                    </li>-->
+                    <li>
+                        <a href="dd.png" target="_blank"
+                            >Developer DAO vibes logo</a
+                        >
+                    </li>
+                    <li>
+                        <a href="pn.png" target="_blank"
+                            >Developer DAO happy hour banner</a
+                        >
+                    </li>
+                    <li>
+                        <a href="vibes.png" target="_blank"
+                            >Developer DAO member hh banner</a
+                        >
+                    </li>
+                </ul>
+            </section>
+
+            <section>
+                <h2>Art Galleries</h2>
+                <ul>
+                    <li><a href="https://deca.art/joshcs/3">Deca</a></li>
+                    <li><a href="https://oncyber.io/joshstein">oncyber</a></li>
+                </ul>
+            </section>
+
+            <footer>
+                <p><a href="verify.html">Verify my identity</a></p>
+            </footer>
         </main>
-
-        <footer class="site-footer">
-            <div class="footer-inner">
-                <div class="footer-status">
-                    <span class="status-dot"></span>
-                    Available for collaboration
-                </div>
-                <div class="footer-links">
-                    <a href="verify.html">Verify my identity</a>
-                    <span class="footer-sep">·</span>
-                    <a href="https://linkedin.com/in/joshcstein">LinkedIn</a>
-                    <span class="footer-sep">·</span>
-                    <a href="https://github.com/jcstein">GitHub</a>
-                </div>
-                <div class="footer-attribution">
-                    <a href="https://www.perplexity.ai/computer" target="_blank" rel="noopener noreferrer">Created with Perplexity Computer</a>
-                </div>
-            </div>
-        </footer>
-
-        <script>
-            // Theme toggle
-            (function () {
-                const toggle = document.querySelector('[data-theme-toggle]');
-                const root = document.documentElement;
-                let theme = root.getAttribute('data-theme') || 'light';
-                updateIcon();
-
-                toggle.addEventListener('click', () => {
-                    theme = theme === 'dark' ? 'light' : 'dark';
-                    root.setAttribute('data-theme', theme);
-                    localStorage.setItem('theme', theme);
-                    updateIcon();
-                });
-
-                function updateIcon() {
-                    toggle.setAttribute('aria-label', 'Switch to ' + (theme === 'dark' ? 'light' : 'dark') + ' mode');
-                    toggle.innerHTML = theme === 'dark'
-                        ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>'
-                        : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-                }
-            })();
-
-            // Sticky nav scroll behavior
-            (function () {
-                const nav = document.getElementById('siteNav');
-                let lastScroll = 0;
-                let ticking = false;
-
-                window.addEventListener('scroll', () => {
-                    if (!ticking) {
-                        requestAnimationFrame(() => {
-                            const currentScroll = window.scrollY;
-                            if (currentScroll > 100) {
-                                nav.classList.add('nav--scrolled');
-                            } else {
-                                nav.classList.remove('nav--scrolled');
-                            }
-                            // Active section highlighting
-                            const sections = document.querySelectorAll('.section[id], .hero[id]');
-                            const navLinks = document.querySelectorAll('.nav-link');
-                            let current = '';
-                            sections.forEach(s => {
-                                const top = s.offsetTop - 120;
-                                if (currentScroll >= top) current = s.getAttribute('id');
-                            });
-                            navLinks.forEach(link => {
-                                link.classList.toggle('nav-link--active', link.getAttribute('href') === '#' + current);
-                            });
-                            lastScroll = currentScroll;
-                            ticking = false;
-                        });
-                        ticking = true;
-                    }
-                });
-            })();
-
-        </script>
     </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,1158 +1,169 @@
-/* ============================================================
-   DESIGN TOKENS
-   ============================================================ */
-
-:root {
-  /* Type scale (fluid) */
-  --text-xs:   clamp(0.75rem,  0.7rem  + 0.25vw, 0.875rem);
-  --text-sm:   clamp(0.875rem, 0.8rem  + 0.35vw, 1rem);
-  --text-base: clamp(1rem,     0.95rem + 0.25vw, 1.125rem);
-  --text-lg:   clamp(1.125rem, 1rem    + 0.75vw, 1.5rem);
-  --text-xl:   clamp(1.5rem,   1.2rem  + 1.25vw, 2.25rem);
-  --text-2xl:  clamp(2rem,     1.2rem  + 2.5vw,  3.5rem);
-  --text-3xl:  clamp(2.5rem,   1rem    + 4vw,    5rem);
-
-  /* Spacing (4px base) */
-  --space-1:  0.25rem;
-  --space-2:  0.5rem;
-  --space-3:  0.75rem;
-  --space-4:  1rem;
-  --space-5:  1.25rem;
-  --space-6:  1.5rem;
-  --space-8:  2rem;
-  --space-10: 2.5rem;
-  --space-12: 3rem;
-  --space-16: 4rem;
-  --space-20: 5rem;
-  --space-24: 6rem;
-  --space-32: 8rem;
-
-  /* Fonts */
-  --font-display: 'JetBrains Mono', 'SF Mono', 'Cascadia Code', monospace;
-  --font-body: 'Satoshi', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-
-  /* Radius */
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-
-  /* Transitions */
-  --transition-fast: 150ms cubic-bezier(0.16, 1, 0.3, 1);
-  --transition-normal: 250ms cubic-bezier(0.16, 1, 0.3, 1);
-
-  /* Content widths */
-  --content-narrow: 680px;
-  --content-default: 960px;
-  --content-wide: 1120px;
-}
-
-
-/* ============================================================
-   LIGHT MODE (default)
-   ============================================================ */
-
-:root, [data-theme="light"] {
-  --color-bg: #f5f4f0;
-  --color-surface: #ffffff;
-  --color-surface-dim: #eceae5;
-  --color-border: #d8d5ce;
-  --color-border-subtle: #e8e6e0;
-  --color-text: #1a1814;
-  --color-text-secondary: #5c5a54;
-  --color-text-muted: #9b9890;
-  --color-accent: #7c5cfc;
-  --color-accent-hover: #6644e8;
-  --color-accent-dim: rgba(124, 92, 252, 0.08);
-  --color-accent-medium: rgba(124, 92, 252, 0.15);
-  --color-success: #22c55e;
-  --color-code-bg: #1e1b2e;
-  --color-code-text: #e2dff0;
-  --color-code-prompt: #7c5cfc;
-  --color-code-cmd: #a5f3fc;
-  --color-code-output: #94a3b8;
-  --color-code-success: #4ade80;
-
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.06);
-  --shadow-lg: 0 8px 24px rgba(0,0,0,0.08);
-  --shadow-card: 0 1px 3px rgba(0,0,0,0.04), 0 0 0 1px var(--color-border-subtle);
-}
-
-
-/* ============================================================
-   DARK MODE
-   ============================================================ */
-
-[data-theme="dark"] {
-  --color-bg: #0e0d10;
-  --color-surface: #18171c;
-  --color-surface-dim: #1f1e24;
-  --color-border: #2e2d34;
-  --color-border-subtle: #252429;
-  --color-text: #e8e6f0;
-  --color-text-secondary: #a09daa;
-  --color-text-muted: #6b6876;
-  --color-accent: #9b80ff;
-  --color-accent-hover: #b49dff;
-  --color-accent-dim: rgba(155, 128, 255, 0.1);
-  --color-accent-medium: rgba(155, 128, 255, 0.18);
-  --color-success: #4ade80;
-  --color-code-bg: #131118;
-  --color-code-text: #e2dff0;
-
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.2);
-  --shadow-md: 0 4px 12px rgba(0,0,0,0.3);
-  --shadow-lg: 0 8px 24px rgba(0,0,0,0.4);
-  --shadow-card: 0 1px 3px rgba(0,0,0,0.2), 0 0 0 1px var(--color-border-subtle);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --color-bg: #0e0d10;
-    --color-surface: #18171c;
-    --color-surface-dim: #1f1e24;
-    --color-border: #2e2d34;
-    --color-border-subtle: #252429;
-    --color-text: #e8e6f0;
-    --color-text-secondary: #a09daa;
-    --color-text-muted: #6b6876;
-    --color-accent: #9b80ff;
-    --color-accent-hover: #b49dff;
-    --color-accent-dim: rgba(155, 128, 255, 0.1);
-    --color-accent-medium: rgba(155, 128, 255, 0.18);
-    --color-success: #4ade80;
-    --color-code-bg: #131118;
-    --color-code-text: #e2dff0;
-    --shadow-sm: 0 1px 2px rgba(0,0,0,0.2);
-    --shadow-md: 0 4px 12px rgba(0,0,0,0.3);
-    --shadow-lg: 0 8px 24px rgba(0,0,0,0.4);
-    --shadow-card: 0 1px 3px rgba(0,0,0,0.2), 0 0 0 1px var(--color-border-subtle);
-  }
-}
-
-
-/* ============================================================
-   BASE RESET
-   ============================================================ */
-
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-html {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-  scroll-behavior: smooth;
-  scroll-padding-top: 80px;
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
 }
 
 body {
-  min-height: 100dvh;
-  line-height: 1.6;
-  font-family: var(--font-body);
-  font-size: var(--text-base);
-  color: var(--color-text);
-  background-color: var(--color-bg);
-  transition: background-color 0.3s ease, color 0.3s ease;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
+    line-height: 1.6;
+    color: #1a1a1a;
+    background: #ffffff;
+    padding: 2rem;
 }
 
-img, picture, video, svg { display: block; max-width: 100%; height: auto; }
-button { cursor: pointer; background: none; border: none; font: inherit; color: inherit; }
-
-h1, h2, h3, h4 { text-wrap: balance; line-height: 1.15; }
-p, li, figcaption { text-wrap: pretty; max-width: 72ch; }
-
-::selection {
-  background: var(--color-accent-medium);
-  color: var(--color-text);
+main {
+    max-width: 720px;
+    margin: 0 auto;
 }
 
-:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 3px;
-  border-radius: var(--radius-sm);
+header {
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 2px solid #1a1a1a;
+}
+
+h1 {
+    font-size: 3rem;
+    font-weight: 900;
+    letter-spacing: -0.03em;
+    margin-bottom: 0.5rem;
+}
+
+.subtitle {
+    font-size: 1.25rem;
+    color: #525252;
+    font-weight: 500;
+}
+
+section {
+    margin-bottom: 4rem;
+}
+
+h2 {
+    font-size: 2rem;
+    font-weight: 800;
+    margin-bottom: 1.5rem;
+    letter-spacing: -0.02em;
+}
+
+p {
+    margin-bottom: 1.25rem;
+    color: #525252;
+    font-size: 1.05rem;
 }
 
 a {
-  color: var(--color-accent);
-  text-decoration: none;
-  transition: color var(--transition-fast);
+    color: #0066ff;
+    text-decoration: none;
+    font-weight: 600;
+    transition: opacity 0.15s ease;
 }
-a:hover { color: var(--color-accent-hover); }
 
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    animation-duration: 0.01ms !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
+a:hover {
+    opacity: 0.7;
 }
 
-
-/* ============================================================
-   NAVIGATION
-   ============================================================ */
-
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background: transparent;
-  transition: background var(--transition-normal), box-shadow var(--transition-normal), backdrop-filter var(--transition-normal);
-}
-
-.site-nav.nav--scrolled {
-  background: color-mix(in srgb, var(--color-bg) 85%, transparent);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  box-shadow: var(--shadow-sm);
-}
-
-.nav-inner {
-  max-width: var(--content-wide);
-  margin: 0 auto;
-  padding: var(--space-3) var(--space-6);
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.nav-logo {
-  color: var(--color-text);
-  text-decoration: none;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-  margin-right: auto;
-}
-
-.wordmark {
-  width: 60px;
-  height: 24px;
-}
-
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-}
-
-.nav-link {
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  padding: var(--space-1) var(--space-3);
-  border-radius: var(--radius-sm);
-  transition: color var(--transition-fast), background var(--transition-fast);
-}
-
-.nav-link:hover {
-  color: var(--color-text);
-  background: var(--color-accent-dim);
-}
-
-.nav-link--active {
-  color: var(--color-accent);
-  background: var(--color-accent-dim);
-}
-
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-sm);
-  color: var(--color-text-secondary);
-  transition: color var(--transition-fast), background var(--transition-fast);
-  margin-left: var(--space-2);
-  flex-shrink: 0;
-}
-
-.theme-toggle:hover {
-  color: var(--color-accent);
-  background: var(--color-accent-dim);
-}
-
-
-/* ============================================================
-   HERO
-   ============================================================ */
-
-.hero {
-  max-width: var(--content-wide);
-  margin: 0 auto;
-  padding: clamp(var(--space-12), 8vw, var(--space-24)) var(--space-6) clamp(var(--space-12), 6vw, var(--space-20));
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: clamp(var(--space-8), 4vw, var(--space-16));
-  align-items: center;
-  min-height: 70vh;
-}
-
-.hero-badge {
-  font-family: var(--font-display);
-  font-size: var(--text-xs);
-  font-weight: 500;
-  color: var(--color-accent);
-  letter-spacing: 0.02em;
-  margin-bottom: var(--space-4);
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.hero-badge::before {
-  content: '';
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-accent);
-  opacity: 0.6;
-}
-
-.hero-title {
-  font-family: var(--font-display);
-  font-size: var(--text-3xl);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  color: var(--color-text);
-  margin-bottom: var(--space-4);
-}
-
-.hero-description {
-  font-size: var(--text-base);
-  color: var(--color-text-secondary);
-  line-height: 1.7;
-  margin-bottom: var(--space-6);
-  max-width: 48ch;
-}
-
-.hero-description a {
-  font-weight: 600;
-}
-
-.hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-4);
-  font-family: var(--font-body);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  border-radius: var(--radius-md);
-  transition: all var(--transition-fast);
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.btn-primary {
-  background: var(--color-accent);
-  color: #fff;
-}
-
-.btn-primary:hover {
-  background: var(--color-accent-hover);
-  color: #fff;
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-md);
-}
-
-.btn-secondary {
-  background: var(--color-surface);
-  color: var(--color-text-secondary);
-  border: 1px solid var(--color-border);
-}
-
-.btn-secondary:hover {
-  color: var(--color-text);
-  border-color: var(--color-accent);
-  background: var(--color-accent-dim);
-  transform: translateY(-1px);
-}
-
-
-/* Code window in hero */
-.hero-visual {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.code-window {
-  width: 100%;
-  max-width: 440px;
-  background: var(--color-code-bg);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-  box-shadow: var(--shadow-lg);
-  border: 1px solid rgba(255,255,255,0.06);
-}
-
-.code-titlebar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  background: rgba(255,255,255,0.03);
-  border-bottom: 1px solid rgba(255,255,255,0.06);
-}
-
-.dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-.dot-red { background: #ff5f57; }
-.dot-yellow { background: #febc2e; }
-.dot-green { background: #28c840; }
-
-.code-filename {
-  font-family: var(--font-display);
-  font-size: 12px;
-  color: rgba(255,255,255,0.4);
-  margin-left: var(--space-2);
-}
-
-.code-body {
-  padding: var(--space-4);
-  font-family: var(--font-display);
-  font-size: 13px;
-  line-height: 1.8;
-  color: var(--color-code-text);
-  overflow-x: auto;
-}
-
-.code-body code {
-  font-family: inherit;
-}
-
-.code-prompt { color: var(--color-code-prompt); font-weight: 600; }
-.code-cmd { color: var(--color-code-cmd); }
-.code-output { color: var(--color-code-output); }
-.code-success { color: var(--color-code-success); font-weight: 600; }
-
-.code-cursor {
-  animation: blink 1.2s step-end infinite;
-  color: var(--color-code-prompt);
-}
-
-@keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0; }
-}
-
-
-/* ============================================================
-   SECTIONS (shared)
-   ============================================================ */
-
-.section {
-  max-width: var(--content-wide);
-  margin: 0 auto;
-  padding: clamp(var(--space-10), 5vw, var(--space-16)) var(--space-6);
-}
-
-.section-header {
-  margin-bottom: clamp(var(--space-6), 3vw, var(--space-10));
-}
-
-.section-title {
-  font-family: var(--font-display);
-  font-size: var(--text-xl);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  color: var(--color-text);
-}
-
-.section-subtitle {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  margin-top: var(--space-2);
-}
-
-
-/* ============================================================
-   ABOUT SECTION
-   ============================================================ */
-
-.philosophy {
-  font-family: var(--font-display);
-  font-size: var(--text-lg);
-  font-weight: 500;
-  color: var(--color-text);
-  border-left: 3px solid var(--color-accent);
-  padding: var(--space-2) var(--space-6);
-  margin-bottom: clamp(var(--space-6), 3vw, var(--space-10));
-  max-width: 48ch;
-  line-height: 1.5;
-  letter-spacing: -0.01em;
-}
-
-.about-grid {
-  display: grid;
-  grid-template-columns: 1fr 280px;
-  gap: clamp(var(--space-8), 4vw, var(--space-12));
-  align-items: start;
-}
-
-.about-text p {
-  color: var(--color-text-secondary);
-  margin-bottom: var(--space-4);
-  line-height: 1.7;
-}
-
-.about-text a {
-  font-weight: 600;
-}
-
-.stack-label {
-  font-family: var(--font-display);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: var(--space-3);
-}
-
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-.tag {
-  display: inline-flex;
-  align-items: center;
-  padding: var(--space-1) var(--space-3);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-sm);
-  font-family: var(--font-display);
-  font-size: 13px;
-  color: var(--color-text-secondary);
-  transition: all var(--transition-fast);
-}
-
-.tag:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-}
-
-
-/* ============================================================
-   FEATURED PROJECTS
-   ============================================================ */
-
-.featured-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-4);
-  margin-bottom: var(--space-6);
-}
-
-.project-card {
-  display: block;
-  text-decoration: none;
-  background: var(--color-surface);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
-  box-shadow: var(--shadow-card);
-  position: relative;
-}
-
-.project-card:hover {
-  transform: translateY(-3px);
-  box-shadow: var(--shadow-md);
-}
-
-.card-accent {
-  height: 3px;
-  background: linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent), #06b6d4 50%));
-  opacity: 0;
-  transition: opacity var(--transition-fast);
-}
-
-.project-card:hover .card-accent {
-  opacity: 1;
-}
-
-.card-content {
-  padding: var(--space-5);
-}
-
-.card-tag {
-  font-family: var(--font-display);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--color-accent);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: var(--space-2);
-}
-
-.card-content h3 {
-  font-family: var(--font-display);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  margin-bottom: var(--space-2);
-}
-
-.card-content p {
-  font-size: 14px;
-  color: var(--color-text-secondary);
-  line-height: 1.6;
-  margin-bottom: var(--space-3);
-}
-
-.card-meta {
-  display: flex;
-  gap: var(--space-3);
-  font-family: var(--font-display);
-  font-size: 12px;
-  color: var(--color-text-muted);
-}
-
-/* Featured card: spans 2 columns on first card */
-.project-card--featured {
-  grid-column: span 2;
-}
-
-.project-card--featured .card-content {
-  padding: var(--space-6);
-}
-
-.project-card--featured h3 {
-  font-size: var(--text-lg);
-}
-
-.project-card--featured p {
-  font-size: var(--text-sm);
-  max-width: 48ch;
+ul {
+    list-style: none;
+    padding: 0;
 }
 
-
-/* More projects toggle */
-.more-projects {
-  margin-top: var(--space-4);
-}
-
-.more-projects--full {
-  margin-top: var(--space-3);
-}
-
-.more-projects--full summary {
-  color: var(--color-text-muted);
-  font-size: var(--text-xs);
-}
-
-.more-projects summary {
-  font-family: var(--font-display);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  padding: var(--space-3) 0;
-  list-style: none;
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  transition: color var(--transition-fast);
-}
-
-.more-projects summary::-webkit-details-marker { display: none; }
-
-.more-projects summary::before {
-  content: '+';
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: var(--radius-sm);
-  background: var(--color-accent-dim);
-  color: var(--color-accent);
-  font-size: 14px;
-  font-weight: 700;
-  transition: transform var(--transition-fast);
-}
-
-.more-projects[open] summary::before {
-  content: '−';
-}
-
-.more-projects summary:hover {
-  color: var(--color-accent);
-}
-
-.more-projects .count {
-  color: var(--color-text-muted);
-  font-weight: 400;
-}
-
-.project-list {
-  list-style: none;
-  padding: var(--space-4) 0 0;
-  columns: 2;
-  column-gap: var(--space-8);
-}
-
-.project-list--grouped {
-  columns: 1;
-  padding-top: var(--space-2);
-}
-
-.archive-groups {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-6);
-  padding-top: var(--space-4);
-}
-
-.archive-group {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  padding: var(--space-4);
-  box-shadow: var(--shadow-card);
-}
-
-.archive-group-title {
-  font-family: var(--font-display);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  letter-spacing: 0.04em;
-}
-
-.project-list li {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  padding: var(--space-2) 0;
-  break-inside: avoid;
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-2);
-}
-
-.project-list li::before {
-  content: '→';
-  color: var(--color-accent);
-  font-weight: 600;
-  flex-shrink: 0;
-}
-
-.project-list li a {
-  font-weight: 600;
-}
-
-
-/* ============================================================
-   TALKS
-   ============================================================ */
-
-.talks-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-8);
-}
-
-.talk-year {
-  font-family: var(--font-display);
-  font-size: var(--text-xl);
-  font-weight: 700;
-  color: var(--color-text-muted);
-  letter-spacing: -0.02em;
-  margin-bottom: var(--space-4);
-  opacity: 0.4;
-}
-
-.talk-items {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.talk-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  padding: var(--space-3) var(--space-4);
-  border-radius: var(--radius-sm);
-  text-decoration: none;
-  color: var(--color-text);
-  transition: background var(--transition-fast);
-  gap: var(--space-4);
-}
-
-a.talk-item:hover {
-  background: var(--color-accent-dim);
-}
-
-.talk-title {
-  font-weight: 600;
-  font-size: var(--text-sm);
-  flex-shrink: 0;
-}
-
-.talk-venue {
-  font-size: var(--text-xs);
-  color: var(--color-text-muted);
-  text-align: right;
-  white-space: nowrap;
-}
-
-
-/* ============================================================
-   WRITING & TUTORIALS
-   ============================================================ */
-
-.writing-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: clamp(var(--space-6), 3vw, var(--space-10));
-}
-
-.writing-grid--single {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.writing-heading {
-  font-family: var(--font-display);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: var(--space-4);
-}
-
-.writing-links {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.writing-link {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--space-3) var(--space-4);
-  border-radius: var(--radius-sm);
-  text-decoration: none;
-  color: var(--color-text);
-  transition: background var(--transition-fast);
-}
-
-.writing-link:hover {
-  background: var(--color-accent-dim);
-}
-
-.writing-platform {
-  font-weight: 600;
-  font-size: var(--text-sm);
-}
-
-.writing-arrow {
-  color: var(--color-text-muted);
-  transition: transform var(--transition-fast), color var(--transition-fast);
-}
-
-.writing-link:hover .writing-arrow {
-  transform: translateX(4px);
-  color: var(--color-accent);
-}
-
-
-/* ============================================================
-   DESIGN & ART
-   ============================================================ */
-
-.design-gallery {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-4);
-  margin-bottom: var(--space-8);
-}
-
-.design-item {
-  display: block;
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  text-decoration: none;
-  border: 1px solid var(--color-border-subtle);
-  transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
-}
-
-.design-item:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-  border-color: var(--color-accent);
-}
-
-.design-item img {
-  width: 100%;
-  height: 180px;
-  object-fit: cover;
-}
-
-.design-caption {
-  display: block;
-  padding: var(--space-3) var(--space-4);
-  font-size: var(--text-xs);
-  color: var(--color-text-secondary);
-  background: var(--color-surface);
-}
-
-.gallery-links {
-  margin-top: var(--space-6);
-}
-
-
-/* ============================================================
-   FOOTER
-   ============================================================ */
-
-.site-footer {
-  border-top: 1px solid var(--color-border-subtle);
-  margin-top: var(--space-16);
-}
-
-.footer-inner {
-  max-width: var(--content-wide);
-  margin: 0 auto;
-  padding: var(--space-8) var(--space-6);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-4);
-  text-align: center;
-}
-
-.footer-status {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-family: var(--font-display);
-  font-size: var(--text-xs);
-  color: var(--color-success);
-}
-
-.status-dot {
-  width: 6px;
-  height: 6px;
-  background: var(--color-success);
-  border-radius: 50%;
-  animation: pulse 2.5s ease infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
+ul li {
+    margin-bottom: 0.75rem;
+    padding-left: 1.5rem;
+    position: relative;
+    color: #525252;
 }
 
-.footer-links {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  font-size: var(--text-sm);
+ul li:before {
+    content: "→";
+    position: absolute;
+    left: 0;
+    color: #0066ff;
+    font-weight: bold;
 }
 
-.footer-links a {
-  color: var(--color-text-secondary);
-  font-weight: 500;
+footer {
+    margin-top: 5rem;
+    padding-top: 2rem;
+    border-top: 2px solid #e5e5e5;
+    text-align: center;
 }
-.footer-links a:hover { color: var(--color-accent); }
 
-.footer-sep {
-  color: var(--color-text-muted);
+.gallery, .design-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+    margin-top: 2rem;
 }
-
-.footer-attribution {
-  font-size: var(--text-xs);
-}
-
-.footer-attribution a {
-  color: var(--color-text-muted);
-  font-weight: 400;
-}
-.footer-attribution a:hover {
-  color: var(--color-accent);
-}
-
-
-/* ============================================================
-   RESPONSIVE
-   ============================================================ */
-
-@media (max-width: 900px) {
-  .hero {
-    grid-template-columns: 1fr;
-    min-height: auto;
-    gap: var(--space-8);
-  }
-
-  .hero-visual {
-    order: -1;
-  }
-
-  .code-window {
-    max-width: 100%;
-  }
-
-  .featured-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .project-card--featured {
-    grid-column: span 2;
-  }
-
-  .about-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 640px) {
-  .nav-links {
-    display: none;
-  }
-
-  .nav-inner {
-    padding: var(--space-3) var(--space-4);
-  }
-
-  .hero {
-    padding-left: var(--space-4);
-    padding-right: var(--space-4);
-  }
-
-  .hero-title {
-    font-size: var(--text-2xl);
-  }
-
-  .hero-actions {
-    gap: var(--space-2);
-  }
-
-  .btn {
-    padding: var(--space-2) var(--space-3);
-    font-size: 13px;
-  }
-
-  .section {
-    padding-left: var(--space-4);
-    padding-right: var(--space-4);
-  }
-
-  .featured-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .project-card--featured {
-    grid-column: span 1;
-  }
-
-  .project-list {
-    columns: 1;
-  }
-
-  .archive-groups {
-    grid-template-columns: 1fr;
-  }
-
-  .talk-item {
-    flex-direction: column;
-    gap: var(--space-1);
-    padding: var(--space-3);
-  }
-
-  .talk-venue {
-    text-align: left;
-    white-space: normal;
-  }
-
-  .writing-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .design-gallery {
-    grid-template-columns: 1fr;
-  }
-
-  .footer-inner {
-    padding: var(--space-6) var(--space-4);
-  }
-}
-
-@media (max-width: 380px) {
-  .hero-actions {
-    flex-direction: column;
-  }
 
-  .hero-actions .btn {
+.gallery img, .design-grid img {
     width: 100%;
-    justify-content: center;
-  }
+    height: auto;
+    border: 2px solid #e5e5e5;
+    transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
-
-/* ============================================================
-   VERIFY PAGE (reuses same tokens)
-   ============================================================ */
-
-.verify-main {
-  max-width: var(--content-narrow);
-  margin: 0 auto;
-  padding: var(--space-12) var(--space-6);
+.gallery img:hover, .design-grid img:hover {
+    transform: scale(1.02);
+    border-color: #0066ff;
 }
 
-.verify-main h1 {
-  font-family: var(--font-display);
-  font-size: var(--text-xl);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin-bottom: var(--space-6);
+.design-grid a {
+    display: block;
+    border: none;
 }
 
-.verify-main p {
-  color: var(--color-text-secondary);
-  margin-bottom: var(--space-4);
-  line-height: 1.7;
+@media (max-width: 768px) {
+    body {
+        padding: 1rem;
+    }
+    
+    h1 {
+        font-size: 2rem;
+    }
+    
+    h2 {
+        font-size: 1.5rem;
+    }
+    
+    .subtitle {
+        font-size: 1.1rem;
+    }
 }
 
-.verify-main strong {
-  color: var(--color-text);
-  font-weight: 600;
-}
-
-.verify-main code {
-  font-family: var(--font-display);
-  font-size: 0.9em;
-  color: var(--color-accent);
-  background: var(--color-accent-dim);
-  padding: 2px 6px;
-  border-radius: var(--radius-sm);
-}
-
-.verify-back {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin-top: var(--space-8);
-  font-weight: 600;
-  color: var(--color-text-secondary);
-}
-.verify-back:hover {
-  color: var(--color-accent);
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #0a0a0a;
+        color: #fafafa;
+    }
+    
+    header {
+        border-bottom-color: #fafafa;
+    }
+    
+    p, ul li {
+        color: #a3a3a3;
+    }
+    
+    .subtitle {
+        color: #a3a3a3;
+    }
+    
+    a {
+        color: #3b82f6;
+    }
+    
+    footer {
+        border-top-color: #262626;
+    }
+    
+    .gallery img, .design-grid img {
+        border-color: #262626;
+    }
+    
+    .gallery img:hover, .design-grid img:hover {
+        border-color: #3b82f6;
+    }
 }

--- a/verify.html
+++ b/verify.html
@@ -1,102 +1,31 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-    <head>
-        <!--
-           ______                            __
-          / ____/___  ____ ___  ____  __  __/ /____  _____
-         / /   / __ \/ __ `__ \/ __ \/ / / / __/ _ \/ ___/
-        / /___/ /_/ / / / / / / /_/ / /_/ / /_/  __/ /
-        \____/\____/_/ /_/ /_/ .___/\__,_/\__/\___/_/
-                            /_/
-                Created with Perplexity Computer
-                https://www.perplexity.ai/computer
-        -->
-
-        <!-- Perplexity Computer Attribution — SEO Meta Tags -->
-        <meta name="generator" content="Perplexity Computer">
-        <meta name="author" content="Perplexity Computer">
-        <meta property="og:see_also" content="https://www.perplexity.ai/computer">
-        <link rel="author" href="https://www.perplexity.ai/computer">
-
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Verify Identity — Josh Stein</title>
-        <link rel="stylesheet" href="style.css" />
-
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-        <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,600,700&display=swap" rel="stylesheet">
-
-        <!-- Analytics -->
-        <script defer data-domain="jcstein.dev" src="https://plausible.io/js/plausible.js"></script>
-
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-                document.documentElement.setAttribute('data-theme', theme);
-            })();
-        </script>
-    </head>
-    <body>
-        <nav class="site-nav nav--scrolled" aria-label="Main navigation">
-            <div class="nav-inner">
-                <a href="index.html" class="nav-logo" aria-label="Josh Stein — home">
-                    <svg viewBox="0 0 80 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="wordmark">
-                        <text x="0" y="18" font-family="'JetBrains Mono', monospace" font-size="18" font-weight="700" fill="currentColor">jcs</text>
-                        <rect x="52" y="4" width="3" height="14" rx="1.5" fill="var(--color-accent)" opacity="0.9"/>
-                    </svg>
-                </a>
-                <button class="theme-toggle" data-theme-toggle aria-label="Switch to dark mode">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-                    </svg>
-                </button>
-            </div>
-        </nav>
-
-        <main class="verify-main">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verify Identity - Josh Stein</title>
+    <link rel="stylesheet" href="style.css">
+    
+    <!-- Analytics -->
+    <script defer data-domain="jcstein.dev" src="https://plausible.io/js/plausible.js"></script>
+</head>
+<body>
+    <main>
+        <header>
             <h1>Verify my identity</h1>
+        </header>
 
-            <p>If you're verifying my identity, my only Telegram is <strong>@josh_cs</strong> (please, don't use this as an invitation to spam me).</p>
+        <section>
+            <p>If you're verifying my identity, my only telegram is <strong>@josh_cs</strong> (please, don't use this as an invitation to spam me).</p>
 
-            <p>My Discord handle is <strong>joshcs.eth</strong> (previously <code>joshcs.eth#3384</code> — same note as above).</p>
+            <p>My discord handle is <strong>joshcs.eth</strong> (previously <code>joshcs.eth#3384</code> -- same note as above, btw).</p>
 
             <p>This is my only <a href="https://linkedin.com/in/joshcstein">LinkedIn portfolio</a>.</p>
+        </section>
 
-            <a href="index.html" class="verify-back">← Back to home</a>
-        </main>
-
-        <footer class="site-footer">
-            <div class="footer-inner">
-                <div class="footer-attribution">
-                    <a href="https://www.perplexity.ai/computer" target="_blank" rel="noopener noreferrer">Created with Perplexity Computer</a>
-                </div>
-            </div>
+        <footer>
+            <p><a href="index.html">← Back to home</a></p>
         </footer>
-
-        <script>
-            (function () {
-                const toggle = document.querySelector('[data-theme-toggle]');
-                const root = document.documentElement;
-                let theme = root.getAttribute('data-theme') || 'light';
-                updateIcon();
-
-                toggle.addEventListener('click', () => {
-                    theme = theme === 'dark' ? 'light' : 'dark';
-                    root.setAttribute('data-theme', theme);
-                    localStorage.setItem('theme', theme);
-                    updateIcon();
-                });
-
-                function updateIcon() {
-                    toggle.setAttribute('aria-label', 'Switch to ' + (theme === 'dark' ? 'light' : 'dark') + ' mode');
-                    toggle.innerHTML = theme === 'dark'
-                        ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>'
-                        : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-                }
-            })();
-        </script>
-    </body>
+    </main>
+</body>
 </html>


### PR DESCRIPTION
## Summary

- Reverts the merge commit `2d322b1` (PR #6) which merged the `staging` branch into `main`
- Uses `git revert -m 1` to cleanly undo the merge while preserving full history
- The `staging` branch is **not touched** — the redesign work remains intact there

## Why

PR #6 merged `staging` (the portfolio redesign) into `main` prematurely. This revert restores `main` to its pre-merge state so the redesign can continue on `staging` without affecting production.

## What changed

Reverts changes to 3 files introduced by PR #6:
- `index.html` (+577 / −1,684 lines net revert)
- `style.css`
- `verify.html`

## Test plan

- [ ] Verify `main` matches its state before PR #6 was merged
- [ ] Confirm `staging` branch is unchanged
- [ ] Check that the deployed site reflects the pre-redesign version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jcstein/jcs/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
